### PR TITLE
Handle the possiblilty that the SQS queue isn't in our own region

### DIFF
--- a/nubis/puppet/files/confd/conf.d/fluentd-collector.toml
+++ b/nubis/puppet/files/confd/conf.d/fluentd-collector.toml
@@ -10,6 +10,7 @@ keys = [
     "/config/SQS/Queue",
     "/config/SQS/AccessKey",
     "/config/SQS/SecretKey",
+    "/config/SQS/Region",
 ]
 
 check_cmd  = "/usr/sbin/td-agent --dry-run -c {{.src}}"

--- a/nubis/puppet/files/confd/templates/fluentd-collector.tmpl
+++ b/nubis/puppet/files/confd/templates/fluentd-collector.tmpl
@@ -26,7 +26,11 @@
      create_queue false
 {{ if exists "/config/SQS/AccessKey" }}aws_key_id {{ getv "/config/SQS/AccessKey" }}{{ end }}
 {{ if exists "/config/SQS/SecretKey" }}aws_sec_key {{ getv "/config/SQS/SecretKey" }}{{ end }}
+{{ if exists "/config/SQS/Region" }}
+     sqs_endpoint sqs.{{ getv "/config/SQS/Region" }}.amazonaws.com
+{{ else }}
      sqs_endpoint sqs.{{ getv "/config/AWSRegion" }}.amazonaws.com
+{{ end }}
    </store>
 {{ end }}
 </match>


### PR DESCRIPTION
Introduce an optionnal KV SQS/Region for this. If set, use it to
build the SQS endpoint, otherwise, just default to our own region

Fixes #37