### PR TITLE
Tag handling

### DIFF
--- a/nubis/puppet/files/confd/conf.d/fluentd-collector.toml
+++ b/nubis/puppet/files/confd/conf.d/fluentd-collector.toml
@@ -1,6 +1,6 @@
 [template]
 src = "fluentd-collector.tmpl"
-dest = "/etc/td-agent/config.d/collector.conf"
+dest = "/etc/td-agent/config.d/zz-collector.conf"
 prefix = "/%%PROJECT%%/%%ENVIRONMENT%%"
 
 keys = [

--- a/nubis/puppet/files/confd/templates/fluentd-collector.tmpl
+++ b/nubis/puppet/files/confd/templates/fluentd-collector.tmpl
@@ -25,8 +25,30 @@
   type prometheus_monitor
 </source>
 
-# Copy everything to S3
+# Tag all events with the environment they came from
+<filter **>
+  type record_transformer
+  <record>
+    environment {{ getv "/config/Environment" }}
+  </record>
+</filter>
+
+# Tag all events with our aws account_id
+<filter **>
+  type ec2_metadata
+  <record>
+    account_id    ${account_id}
+  </record>
+</filter>
+
+# Strip out the ec2.forward tag
 <match ec2.forward.**>
+  type retag
+  remove_prefix ec2.forward
+</match>
+
+# Copy everything outbound
+<match **>
     type copy
     <store>
     type s3

--- a/nubis/puppet/files/fluent-startup
+++ b/nubis/puppet/files/fluent-startup
@@ -11,9 +11,9 @@ ES_ENDPOINT=$(nubis-metadata NUBIS_FLUENT_ES_ENDPOINT)
 
 PREFIX="$PROJECT/$ENVIRONMENT/config"
 
-# Make sure our region is in our config
+# Make sure our region/environment is in our config
 consulate kv set "$PREFIX/AWSRegion" "$REGION"
-
+consulate kv set "$PREFIX/Environment" "$ENVIRONMENT"
 
 # Publish our settings into Consul, careful to clean up and delete
 # what might have been there but isn't currently specified anymore

--- a/nubis/puppet/fluentd.pp
+++ b/nubis/puppet/fluentd.pp
@@ -1,5 +1,11 @@
 include ::fluentd
 
+fluentd::install_plugin { 'retag':
+  ensure      => '0.0.2',
+  plugin_name => 'fluent-plugin-retag',
+  plugin_type => 'gem',
+}
+
 fluentd::install_plugin { 'prometheus':
   ensure      => '0.2.0',
   plugin_name => 'fluent-plugin-prometheus',


### PR DESCRIPTION
use record_transformer to add environment tag
  - use ec2_metadata to add account_id
  - use retag to strip the ugly ec2.forward prefix

And this finally allows us to blindly forward all events to our backing
store.

Fixes #107