### PR TITLE
Handle correcltly fluentd user-data with or without ES enabled

### DIFF
--- a/nubis/terraform/multi/main.tf
+++ b/nubis/terraform/multi/main.tf
@@ -312,8 +312,10 @@ NUBIS_ACCOUNT="${var.service_name}"
 NUBIS_DOMAIN="${var.nubis_domain}"
 NUBIS_FLUENT_BUCKET="${element(aws_s3_bucket.fluent.*.id, count.index)}"
 NUBIS_ELB_BUCKET="${element(aws_s3_bucket.elb.*.id, count.index)}"
-NUBIS_FLUENT_ES_ENDPOINT="${coalesce(aws_elasticsearch_domain.fluentd.endpoint,"")}"
+NUBIS_FLUENT_ES_ENDPOINT="${coalesce(element(aws_elasticsearch_domain.fluentd.*.endpoint, 0),"")}"
 EOF
+
+# XXX: TF edge: the coalesce(element(splat.*.endpoint,0),"") is necessary
 }
 
 resource "aws_autoscaling_group" "fluent-collector" {

--- a/nubis/terraform/multi/main.tf
+++ b/nubis/terraform/multi/main.tf
@@ -312,7 +312,7 @@ NUBIS_ACCOUNT="${var.service_name}"
 NUBIS_DOMAIN="${var.nubis_domain}"
 NUBIS_FLUENT_BUCKET="${element(aws_s3_bucket.fluent.*.id, count.index)}"
 NUBIS_ELB_BUCKET="${element(aws_s3_bucket.elb.*.id, count.index)}"
-NUBIS_FLUENT_ES_ENDPOINT="${aws_elasticsearch_domain.fluentd.endpoint}"
+NUBIS_FLUENT_ES_ENDPOINT="${coalesce(aws_elasticsearch_domain.fluentd.endpoint,"")}"
 EOF
 }
 
@@ -388,6 +388,29 @@ resource "aws_elasticsearch_domain" "fluentd" {
         "es:ESHttpPut",
         "es:ESHttpDelete"
       ],
+      "Resource": "arn:aws:es:${var.aws_region}:${var.aws_account_id}:domain/${var.project}/*"
+    },
+    {
+      "Sid": "XXX: Temporary, allow read-only access to anonymous users",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "es:ESHttpGet",
+        "es:ESHttpHead",
+        "es:ESHttpPost",
+	"es:ESHttpPut",
+        "es:ESHttpDelete"
+      ],
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": [
+            "174.92.184.0/24",
+            "68.109.230.10/24"
+           ]
+        }
+      },
       "Resource": "arn:aws:es:${var.aws_region}:${var.aws_account_id}:domain/${var.project}/*"
     }
   ]


### PR DESCRIPTION
Normally, one would expect this to work:
```
NUBIS_FLUENT_ES_ENDPOINT="${coalesce(aws_elasticsearch_domain.fluentd.endpoint,"")}"
```

But turns out one has to cheat with a splat+element to avoid errors when count=0
```
NUBIS_FLUENT_ES_ENDPOINT="${coalesce(element(aws_elasticsearch_domain.fluentd.*.endpoint, 0),"")}"
```